### PR TITLE
Fix Unnecessary Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 cache: pip
 script:
-  - '[[ "${TRAVIS_COMMIT_MESSAGE}" == *"Deploy"* ]] && exit 0'
+  - '[[ "${TRAVIS_COMMIT_MESSAGE}" == *"Deploy"* ]] && exit 0 || true'
   - make publish
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 cache: pip
 script:
-  - [ "${TRAVIS_COMMIT_MESSAGE#*Deploy}" != "$TRAVIS_COMMIT_MESSAGE" ] && exit 0 || make publish
+  - [[ "${TRAVIS_COMMIT_MESSAGE#*Deploy}" != "$TRAVIS_COMMIT_MESSAGE" ]] && exit 0 || make publish
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 cache: pip
 script:
-  - [[ "${TRAVIS_COMMIT_MESSAGE}" == *"Deploy"* ]] && exit 0
+  - '[[ "${TRAVIS_COMMIT_MESSAGE}" == *"Deploy"* ]] && exit 0'
   - make publish
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "3.6"
 cache: pip
 script:
-  - [[ "${TRAVIS_COMMIT_MESSAGE#*Deploy}" != "$TRAVIS_COMMIT_MESSAGE" ]] && exit 0 || make publish
+  - [[ "${TRAVIS_COMMIT_MESSAGE}" == *"Deploy"* ]] && exit 0
+  - make publish
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 cache: pip
 script:
-  - make publish
+  - [ "${TRAVIS_COMMIT_MESSAGE#*Deploy}" != "$TRAVIS_COMMIT_MESSAGE" ] && exit 0 || make publish
 branches:
   only:
     - master

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ help:
 
 .PHONY: help Makefile
 
+prepare:
+	mv docs/jncip-dc-notes.pdf ./jncip-dc-notes.pdf
+
 clean:
 	rm -rf _build/*
 	rm -rf docs/*
@@ -25,10 +28,11 @@ html:
 
 pdf:
 	@$(SPHINXBUILD) -M rinoh "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	[ `du -k "_build/rinoh/jncip-dc-notes.pdf"` -eq `du -k "docs/jncip-dc-notes.pdf"` ] && exit 0
+	mv jncip-dc-notes.pdf docs/jncip-dc-notes.pdf || true
+	[ `du -k "_build/rinoh/jncip-dc-notes.pdf"` -eq `du -k "docs/jncip-dc-notes.pdf"` ] && exit 0 || true
 	mv _build/rinoh/jncip-dc-notes.pdf docs/
 
-publish: clean html pdf
+publish: prepare clean html pdf
 	echo "jncip-dc.tylerc.me" > docs/CNAME
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,13 @@ html:
 
 pdf:
 	@$(SPHINXBUILD) -M rinoh "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	[ `du -k "_buid/rinoh/jncip-dc-notes.pdf"` -eq `du -k "docs/jncip-dc-notes.pdf"` ] && exit 0
 	mv _build/rinoh/jncip-dc-notes.pdf docs/
 
 build: clean html pdf
 	echo "jncip-dc.tylerc.me" > docs/CNAME
 
 publish: build
-	[ "$(TRAVIS_PULL_REQUEST_BRANCH)" ] && exit 0 || true
-	git add .
-	git commit -m "publish version: $(TRAVIS_COMMIT)"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,11 @@ html:
 
 pdf:
 	@$(SPHINXBUILD) -M rinoh "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	[ `du -k "_buid/rinoh/jncip-dc-notes.pdf"` -eq `du -k "docs/jncip-dc-notes.pdf"` ] && exit 0
+	[ `du -k "_build/rinoh/jncip-dc-notes.pdf"` -eq `du -k "docs/jncip-dc-notes.pdf"` ] && exit 0
 	mv _build/rinoh/jncip-dc-notes.pdf docs/
 
-build: clean html pdf
+publish: clean html pdf
 	echo "jncip-dc.tylerc.me" > docs/CNAME
-
-publish: build
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
This (hopefully) prevents Travis from cyclically republishing the same thing because it sees itself committing to the repo.  It also (hopefully) prevents PDFs from being committed to the repo when the size doesn't change.  Longer term, it would be good to put the PDFs in S3 since they're binary.